### PR TITLE
use webpack -p

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -24,7 +24,7 @@ for num in 100 1000 5000; do
 
   browserify ./lib/cjs-${num} > dist/browserify-${num}.js
   browserify -p bundle-collapser/plugin ./lib/cjs-${num} > dist/browserify-collapsed-${num}.js
-  webpack --entry ./lib/cjs-${num} --output-filename dist/webpack-${num}.js >/dev/null
+  webpack -p --entry ./lib/cjs-${num} --output-filename dist/webpack-${num}.js >/dev/null
   rollup --format iife ./lib/es6-${num}/index.js > dist/rollup-${num}.js
   ccjs lib/es6-${num}/* --compilation_level=ADVANCED_OPTIMIZATIONS \
     --language_in=ECMASCRIPT6_STRICT --output_wrapper="(function() {%output%})()" > dist/closure-${num}.js


### PR DESCRIPTION
It was mentioned in a [comment](https://nolanlawson.com/2016/08/15/the-cost-of-small-modules/#comment-84292) that we should use the production `-p` flag for Webpack. I checked and it doesn't change the output much given Uglify, but it's worth doing this just to address the criticism and because maybe there is indeed a slight difference between defining the modules in `require()` order (1, 2, 3, 4, 5) rather than lexicographic module name order (1, 10, 2, 20, ...).
