### PR TITLE
Modifying generation script to correctly import and use the modules that export numbers.

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -16,7 +16,7 @@ for num in 100 1000 5000; do
     echo "module.exports = ${i}" > lib/cjs-${num}/module_${i}.js
     echo "export default ${i}" > lib/es6-${num}/module_${i}.js
     echo "total += require('./module_${i}')" >> lib/cjs-${num}/index.js
-    echo -e "import module_${i} from './module_${i}'\ntotal += ${i}" >> lib/es6-${num}/index.js
+    echo -e "import module_${i} from './module_${i}'\ntotal += module_${i}" >> lib/es6-${num}/index.js
   done
 
   echo "console.log(total)" >> lib/cjs-${num}/index.js


### PR DESCRIPTION
I think I found a bug in the generation script for ES6 modules that affects the results in a real way.

As written, `lib/es6-{num}/index.js` gets written out like this:

```
var total = 0
import module_0 from './module_0'
total += 0
import module_1 from './module_1'
total += 1
/* and so on... */
```

This means that `index.js` never actually uses the value exported from the child modules. All those imports just get thrown away by rollup. I've changed the generation script so that it generates the following:

```
var total = 0
import module_0 from './module_0'
total += module_0
import module_1 from './module_1'
total += module_1
/* and so on... */
```

On my local runs of the benchmark, this change more than doubles the amount of time that rollup takes overall. (Closure is smart enough to inline the vars, btw.)

Rollup is still faster than webpack, even with optimize-js patched for webpack bundles, but the comparison is a heckuva lot closer.

Thanks for all your work on this; you are great!
