### PR TITLE
Update to Webpack 3

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -24,7 +24,7 @@ for num in 100 1000 5000; do
 
   browserify ./lib/cjs-${num} > dist/browserify-${num}.js
   browserify -p bundle-collapser/plugin ./lib/cjs-${num} > dist/browserify-collapsed-${num}.js
-  webpack -p --entry ./lib/cjs-${num} --output-filename dist/webpack-${num}.js >/dev/null
+  webpack -p --display-optimization-bailout --entry ./lib/es6-${num}/index.js --output-filename dist/webpack-${num}.js >> /dev/null
   rollup --format iife ./lib/es6-${num}/index.js > dist/rollup-${num}.js
   ccjs lib/es6-${num}/* --compilation_level=ADVANCED_OPTIMIZATIONS \
     --language_in=ECMASCRIPT6_STRICT --output_wrapper="(function() {%output%})()" > dist/closure-${num}.js

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "rollup": "^0.34.7",
     "serve": "^1.4.0",
     "uglify-js": "^2.7.0",
-    "webpack": "^1.13.1"
+    "webpack": "^3.0.0"
   },
   "devDependencies": {},
   "keywords": [],


### PR DESCRIPTION
Updates Webpack to version 3 with module concatenation plugin enabled.

Size:
```
ungzipped:
||100 modules|1000 modules|5000 modules|
| ---- | ---- | ---- | ---- |
|browserify|    7981|   79985|  419984|
|browserify-collapsed|    5785|   57989|  309981|
|webpack|    1185|    7485|   39482|
|rollup|     671|    6971|   38968|
|closure|     758|    7958|   43956|
|rjs|   29168|  136272|  628282|
|rjs-almond|   14499|  121603|  613613|
gzipped:
||100 modules|1000 modules|5000 modules|
| ---- | ---- | ---- | ---- |
|browserify|    1649|   13775|   63617|
|browserify-collapsed|    1463|   11840|   55588|
|webpack|     575|    2491|   11883|
|rollup|     300|    2135|   11449|
|closure|     302|    2140|   11808|
|rjs|    7940|   19013|   62646|
|rjs-almond|    2735|   13185|   56109|
```

Runtime performance:
```
100 modules,,,
Bundler,Load time (ms),Run time (ms),Total time (ms)
browserify,3.99,2.03,6.02
browserify-collapsed,3.61,2.14,5.75
webpack,4.83,0.51,5.33
rollup,4.67,0.32,4.99
closure,4.82,0.33,5.15
rjs,5.73,0.59,6.32
rjs-almond,5.34,0.61,5.95
1000 modules,,,
Bundler,Load time (ms),Run time (ms),Total time (ms)
browserify,11.29,19.88,31.17
browserify-collapsed,9.64,18.9,28.54
webpack,5.19,0.85,6.04
rollup,5.06,0.74,5.8
closure,4.97,0.89,5.86
rjs,11.95,1.01,12.97
rjs-almond,10.22,1.99,12.2
5000 modules,,,
Bundler,Load time (ms),Run time (ms),Total time (ms)
browserify,43.19,67.09,110.28
browserify-collapsed,40.18,69.6,109.78
webpack,4.91,2.93,7.83
rollup,5.31,2.53,7.83
closure,5.63,3.32,8.94
rjs,40.68,2.64,43.32
rjs-almond,40.58,6.4,46.99
Done!
```