### PR TITLE
Change bundle-collapser for browser-pack-flat

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -23,7 +23,7 @@ for num in 100 1000 5000; do
   echo "console.log(total)" >> lib/es6-${num}/index.js
 
   browserify ./lib/cjs-${num} > dist/browserify-${num}.js
-  browserify -p bundle-collapser/plugin ./lib/cjs-${num} > dist/browserify-collapsed-${num}.js
+  browserify -p browser-pack-flat/plugin ./lib/cjs-${num} > dist/browserify-flat-${num}.js
   webpack -p --entry ./lib/cjs-${num} --output-filename dist/webpack-${num}.js >/dev/null
   rollup --format iife ./lib/es6-${num}/index.js > dist/rollup-${num}.js
   ccjs lib/es6-${num}/* --compilation_level=ADVANCED_OPTIMIZATIONS \

--- a/bin/print-sizes.sh
+++ b/bin/print-sizes.sh
@@ -11,7 +11,7 @@ echo
 
 echo '| ---- | ---- | ---- | ---- |'
 
-for bundler in browserify browserify-collapsed webpack rollup closure rjs rjs-almond; do
+for bundler in browserify browserify-flat webpack rollup closure rjs rjs-almond; do
   printf '|'
   printf $bundler
   printf '|'
@@ -33,7 +33,7 @@ echo
 
 echo '| ---- | ---- | ---- | ---- |'
 
-for bundler in browserify browserify-collapsed webpack rollup closure rjs rjs-almond; do
+for bundler in browserify browserify-flat webpack rollup closure rjs rjs-almond; do
   printf '|'
   printf $bundler
   printf '|'

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "almond": "^0.3.2",
+    "browser-pack-flat": "^3.0.5",
     "browserify": "^13.1.0",
     "buble": "^0.13.1",
-    "bundle-collapser": "^1.2.1",
     "closurecompiler": "^1.6.0",
     "lodash.times": "^4.3.2",
     "mkdirp": "^0.5.1",

--- a/script.js
+++ b/script.js
@@ -6,7 +6,7 @@
   // do this many iterations and then take the median
   var ITERATIONS = 15
   var NUM_MODULES = [ '100', '1000', '5000' ]
-  var BUNDLERS = [ 'browserify', 'browserify-collapsed', 'webpack', 'rollup', 'closure', 'rjs', 'rjs-almond' ]
+  var BUNDLERS = [ 'browserify', 'browserify-flat', 'webpack', 'rollup', 'closure', 'rjs', 'rjs-almond' ]
 
   var results = document.querySelector('#results')
   var button = document.querySelector('#run-test')


### PR DESCRIPTION
I replaced `bundle-collapser` with `browser-pack-flat` which is able to do a similar thing to Rollup's inlining but it works for CommonJS.

A sample test result from Safari 11.0.1 (note: I removed Closure from the results as it didn't build correctly for me):

#### 100 modules

| Bundler         |  Load time (ms) |  Run time (ms) |  Total time (ms) |
|-----------------|-----------------|----------------|------------------|
| browserify      |  3              |  0.4           |  3.4             |
| browserify-flat |  2.6            |  0             |  2.6             |
| webpack         |  2.3            |  0.5           |  2.8             |
| rollup          |  2.2            |  0.1           |  2.3             |
| rjs             |  3.5            |  0.1           |  3.6             |
| rjs-almond      |  2.5            |  0.3           |  2.8             |

#### 1000 modules

| Bundler         |  Load time (ms) |  Run time (ms) |  Total time (ms) |
|-----------------|-----------------|----------------|------------------|
| browserify      |  4.8            |  3             |  7.8             |
| browserify-flat |  2.5            |  0             |  2.5             |
| webpack         |  3.4            |  2.1           |  5.5             |
| rollup          |  2.4            |  0             |  2.4             |
| rjs             |  4.5            |  0.3           |  4.8             |
| rjs-almond      |  3.9            |  0.7           |  4.6             |

#### 5000 modules

| Bundler         |  Load time (ms) |  Run time (ms) |  Total time (ms) |
|-----------------|-----------------|----------------|------------------|
| browserify      |  11.6           |  14            |  25.6            |
| browserify-flat |  3.9            |  0.2           |  4.1             |
| webpack         |  8              |  6.9           |  14.9            |
| rollup          |  3.6            |  0.1           |  3.7             |
| rjs             |  12.6           |  1.7           |  14.3            |
